### PR TITLE
Fix auto confirming user even if they have left before the 2 minutes

### DIFF
--- a/src/resources/events/on_member_join.py
+++ b/src/resources/events/on_member_join.py
@@ -49,7 +49,7 @@ class MemberJoinEvent(Bloxlink.Module):
                     except discord.errors.HTTPException:
                         pass
             else:
-                if auto_verification or auto_roles:
+                if (auto_verification or auto_roles) and guild.get_member(member.id):
                     try:
                         roblox_user = (await get_user(user=member))[0]
                     except UserNotVerified:


### PR DESCRIPTION
Previously, if a user has left before the automatic account confirmation kicks in, and the bot would DM you saying it verified you even though you left the server.

I'm not a master python coder so if there's anything wrong with this or a better way to do it, let me know! 😁 

(Previously posted as a bug report by Alfred#3865 in November 2022, but it still seems to be there)